### PR TITLE
wr401629: Add in language string to fix failing unit test

### DIFF
--- a/lang/en/atto_sharing.php
+++ b/lang/en/atto_sharing.php
@@ -40,3 +40,4 @@ $string["linkedin"] = 'Linkedin Share';
 $string["twiter"] = 'Twiter Share';
 $string["googleplus_share"] = 'Gooele Plus Share';
 $string["url"] = 'Sharing URL';
+$string['privacy:metadata'] = 'The Atto Sharing plugin does not store any personal data.';


### PR DESCRIPTION
Add in language string to correct failing behat test:

`1) core_privacy\privacy\provider_test::test_null_provider with data set "atto_sharing" ('atto_sharing', 'atto_sharing\privacy\provider')
Expectation failed, debugging() was triggered.
Debugging: Invalid get_string() identifier: 'privacy:metadata' or component 'atto_sharing'. Perhaps you are missing $string['privacy:metadata'] = ''; in /var/www/site/lib/editor/atto/plugins/sharing/lang/en/atto_sharing.php`